### PR TITLE
refactor: modularizar datos y utilidades mock

### DIFF
--- a/XboxNow Professional Scraper Web Application/README.md
+++ b/XboxNow Professional Scraper Web Application/README.md
@@ -169,6 +169,22 @@ Product Name,Full description,Short summary,9.99,https://delivery-url.com,https:
 3. Crea nuevo webhook
 4. Copia la URL
 
+### Modo Mock
+
+Para habilitar datos simulados y utilidades de demostración, activa el modo mock con la variable de entorno `VITE_USE_MOCKS`:
+
+```bash
+VITE_USE_MOCKS=true npm run dev
+```
+
+Para desactivar el modo mock simplemente ejecuta los scripts sin la variable:
+
+```bash
+npm run dev
+```
+
+Los módulos dentro de `mocks/` generan datos y comportamientos ficticios cuando este modo está activado.
+
 ## ⌨️ Atajos de Teclado (Electron)
 
 - `F5` - Iniciar scraping

--- a/XboxNow Professional Scraper Web Application/components/BulkUploadManager.tsx
+++ b/XboxNow Professional Scraper Web Application/components/BulkUploadManager.tsx
@@ -12,10 +12,10 @@ import { Switch } from './ui/switch';
 import { Checkbox } from './ui/checkbox';
 import { Separator } from './ui/separator';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
-import { 
-  Upload, 
-  Play, 
-  Pause, 
+import {
+  Upload,
+  Play,
+  Pause,
   Square,
   CheckCircle,
   XCircle,
@@ -32,6 +32,7 @@ import {
   Eye,
   EyeOff
 } from 'lucide-react';
+import { simulateNetworkDelay, mockUploadSuccess } from '../mocks/demoUtils';
 
 interface GameUploadItem {
   id: string;
@@ -256,10 +257,10 @@ export function BulkUploadManager() {
   // Simulate upload to platform
   const uploadToPlatform = async (item: GameUploadItem, platform: string): Promise<boolean> => {
     // Simulate API call delay
-    await new Promise(resolve => setTimeout(resolve, 1000 + Math.random() * 2000));
-    
+    await simulateNetworkDelay();
+
     // Simulate success/failure (90% success rate)
-    const success = Math.random() > 0.1;
+    const success = mockUploadSuccess();
     
     if (success) {
       updateItem(item.id, {

--- a/XboxNow Professional Scraper Web Application/components/XboxProductViewer.tsx
+++ b/XboxNow Professional Scraper Web Application/components/XboxProductViewer.tsx
@@ -26,6 +26,8 @@ import {
 import { useXboxAPI, XBOX_MARKETS } from '../hooks/useXboxAPI';
 import { ImageWithFallback } from './figma/ImageWithFallback';
 import { ProductDetails } from '../types/scraper';
+import { randomFloat, randomBool, mockEnabled } from '../mocks/random';
+import { simulateNetworkDelay } from '../mocks/demoUtils';
 
 // Enhanced Xbox game data interface for the viewer
 interface XboxGameData {
@@ -130,15 +132,16 @@ export function XboxProductViewer() {
 
   // Mock function to fetch detailed game data
   const fetchGameData = useCallback(async (productId: string, region: string): Promise<XboxGameData | null> => {
+    if (!mockEnabled) return null;
     // Simulate API call delay
-    await new Promise(resolve => setTimeout(resolve, 1000));
-    
+    await simulateNetworkDelay();
+
     // Generate mock data based on product ID
     const mockData: XboxGameData = {
       productId,
       title: productId === '9NGBNVMFXPT6' ? 'Halo Infinite' : `Xbox Game ${productId.slice(-4)}`,
       description: 'Master Chief returns in the most ambitious Halo game ever created. Explore the vast world of Zeta Halo and experience the most wide-open and adventure-filled Halo campaign yet.',
-      price: Math.round((Math.random() * 50 + 10) * 100) / 100,
+      price: Math.round(randomFloat(10, 60) * 100) / 100,
       currency: getCurrencyForRegion(region),
       region,
       locale: getLanguageForRegion(region),
@@ -146,8 +149,8 @@ export function XboxProductViewer() {
       publisher: 'Microsoft Studios',
       releaseDate: '2021-12-08',
       rating: 4.5,
-      discount: Math.random() > 0.7 ? Math.round(Math.random() * 50) : 0,
-      isOnSale: Math.random() > 0.7,
+      discount: randomBool(0.7) ? Math.round(randomFloat(0, 50)) : 0,
+      isOnSale: randomBool(0.7),
       categories: ['Games', 'Action & adventure', 'Shooter'],
       platforms: ['Xbox Series X|S', 'Xbox One', 'PC'],
       features: ['4K Ultra HD', 'HDR10', 'Spatial Audio', 'Xbox Live Gold', 'Smart Delivery'],

--- a/XboxNow Professional Scraper Web Application/components/ui/sidebar.tsx
+++ b/XboxNow Professional Scraper Web Application/components/ui/sidebar.tsx
@@ -24,6 +24,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "./tooltip";
+import { randomSidebarWidth } from "../../mocks/demoUtils";
 
 const SIDEBAR_COOKIE_NAME = "sidebar_state";
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
@@ -608,7 +609,7 @@ function SidebarMenuSkeleton({
 }) {
   // Random width between 50 to 90%.
   const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
+    return randomSidebarWidth();
   }, []);
 
   return (

--- a/XboxNow Professional Scraper Web Application/hooks/useScraper.ts
+++ b/XboxNow Professional Scraper Web Application/hooks/useScraper.ts
@@ -1,95 +1,13 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
 import { Game, RegionStats, PriceHistory, ScrapingProgress, ScrapingConfig } from '../types/scraper';
-
-// Mock data para desarrollo
-const mockGames: Game[] = [
-  {
-    id: '1',
-    title: 'Halo Infinite',
-    productId: '9PP5G1F0C2B6',
-    region: 'US',
-    imageUrl: 'https://store-images.s-microsoft.com/image/apps.1692.13727851868390641.c9cc5f66-aff8-406c-8c45-8cd48d31bb8d.57f1c8c9-b2c7-416b-b2bb-e89551bb24c7',
-    lowestPriceUsd: 0,
-    originalPriceUsd: 59.99,
-    discount: 100,
-    currency: 'USD',
-    dealUntil: '2024-12-31',
-    releaseDate: '2021-12-08',
-    developer: '343 Industries',
-    publisher: 'Microsoft Studios',
-    categories: ['Action', 'Shooter'],
-    platforms: ['Xbox', 'PC'],
-    description: 'Master Chief returns in Halo Infinite – the next chapter of the legendary franchise.',
-    rating: 'T',
-    url: 'https://www.xbox.com/games/halo-infinite',
-    lastUpdated: new Date().toISOString()
-  },
-  {
-    id: '2',
-    title: 'Forza Horizon 5',
-    productId: '9NKX70BBXVGZ',
-    region: 'US',
-    imageUrl: 'https://store-images.s-microsoft.com/image/apps.12467.13727851868390641.c9cc5f66-aff8-406c-8c45-8cd48d31bb8d.57f1c8c9-b2c7-416b-b2bb-e89551bb24c7',
-    lowestPriceUsd: 29.99,
-    originalPriceUsd: 59.99,
-    discount: 50,
-    currency: 'USD',
-    dealUntil: '2024-01-15',
-    releaseDate: '2021-11-09',
-    developer: 'Playground Games',
-    publisher: 'Microsoft Studios',
-    categories: ['Racing', 'Sports'],
-    platforms: ['Xbox', 'PC'],
-    description: 'Your Ultimate Horizon Adventure awaits! Explore the vibrant and ever-evolving open world landscapes of Mexico.',
-    rating: 'T',
-    url: 'https://www.xbox.com/games/forza-horizon-5',
-    lastUpdated: new Date().toISOString()
-  }
-];
-
-const mockRegionStats: RegionStats[] = [
-  {
-    region: 'US',
-    totalGames: 2456,
-    averageDiscount: 35,
-    totalValue: 125000,
-    currency: 'USD',
-    lastUpdated: new Date().toISOString()
-  },
-  {
-    region: 'AR',
-    totalGames: 1890,
-    averageDiscount: 42,
-    totalValue: 85000,
-    currency: 'ARS',
-    lastUpdated: new Date().toISOString()
-  }
-];
-
-const mockPriceHistory: PriceHistory[] = [
-  {
-    productId: '9PP5G1F0C2B6',
-    region: 'US',
-    date: '2024-01-01',
-    price: 59.99,
-    discount: 0,
-    currency: 'USD'
-  },
-  {
-    productId: '9PP5G1F0C2B6',
-    region: 'US',
-    date: '2024-01-15',
-    price: 29.99,
-    discount: 50,
-    currency: 'USD'
-  }
-];
+import { mockGames, mockRegionStats, mockPriceHistory, generateMockGame } from '../mocks/scraper';
+import { randomInt, randomBool, mockEnabled } from '../mocks/random';
 
 export function useScraper() {
-  const [games, setGames] = useState<Game[]>(mockGames);
+  const [games, setGames] = useState<Game[]>(mockEnabled ? mockGames : []);
   const [selectedGames, setSelectedGames] = useState<Set<string>>(new Set());
-  const [regionStats, setRegionStats] = useState<RegionStats[]>(mockRegionStats);
-  const [priceHistory, setPriceHistory] = useState<PriceHistory[]>(mockPriceHistory);
+  const [regionStats, setRegionStats] = useState<RegionStats[]>(mockEnabled ? mockRegionStats : []);
+  const [priceHistory, setPriceHistory] = useState<PriceHistory[]>(mockEnabled ? mockPriceHistory : []);
   const [progress, setProgress] = useState<ScrapingProgress>({
     isActive: false,
     status: 'Ready',
@@ -130,7 +48,7 @@ export function useScraper() {
         if (scrapingWorkerRef.current?.signal.aborted) break;
 
         processedPages++;
-        const gamesPerPage = Math.floor(Math.random() * 20) + 5; // 5-25 games per page
+        const gamesPerPage = mockEnabled ? randomInt(5, 25) : 0;
         processedGames += gamesPerPage;
 
         setProgress(prev => ({
@@ -141,29 +59,8 @@ export function useScraper() {
         }));
 
         // Simulate finding new games
-        if (Math.random() > 0.7) { // 30% chance of finding new games
-          const newGame: Game = {
-            id: `game-${Date.now()}-${Math.random()}`,
-            title: `Sample Game ${processedGames}`,
-            productId: `9N${Math.random().toString(36).substring(2, 8).toUpperCase()}`,
-            region,
-            imageUrl: 'https://via.placeholder.com/300x400',
-            lowestPriceUsd: Math.random() * 60,
-            originalPriceUsd: Math.random() * 80 + 20,
-            discount: Math.floor(Math.random() * 90),
-            currency: region === 'US' ? 'USD' : 'EUR',
-            dealUntil: Math.random() > 0.5 ? '2024-12-31' : '',
-            releaseDate: new Date(Date.now() - Math.random() * 365 * 24 * 60 * 60 * 1000).toISOString().split('T')[0],
-            developer: 'Sample Developer',
-            publisher: 'Sample Publisher',
-            categories: ['Action', 'Adventure'],
-            platforms: ['Xbox', 'PC'],
-            description: 'A sample game description',
-            rating: 'T',
-            url: 'https://www.xbox.com/games/sample',
-            lastUpdated: new Date().toISOString()
-          };
-
+        if (mockEnabled && randomBool(0.7)) {
+          const newGame = generateMockGame(region, processedGames);
           setGames(prev => [...prev, newGame]);
         }
 

--- a/XboxNow Professional Scraper Web Application/hooks/useXboxAPI.ts
+++ b/XboxNow Professional Scraper Web Application/hooks/useXboxAPI.ts
@@ -1,5 +1,7 @@
 import { useState, useCallback, useEffect } from 'react';
 import { ProductDetails, RegionalPriceData, RegionalPrice, XboxMarket, MarketAnalysis } from '../types/scraper';
+import { mockEnabled } from '../mocks/random';
+import { generateMockRegionalPrice } from '../mocks/pricing';
 
 // Lista completa de mercados de Xbox (200+ regiones)
 export const XBOX_MARKETS: XboxMarket[] = [
@@ -247,26 +249,8 @@ export const useXboxAPI = () => {
       const url = buildXboxAPIUrl(productId, market);
       
       // En un navegador, usar datos mock para evitar CORS
-      if (typeof window !== 'undefined' && !window.electronAPI) {
-        // Generar datos mock realistas
-        const basePrice = Math.random() * 60 + 10; // Precio base entre $10-70
-        const discountPercent = Math.random() > 0.7 ? Math.random() * 80 : 0; // 30% chance de descuento
-        const originalPrice = basePrice / (1 - discountPercent / 100);
-        
-        return {
-          region: market.region,
-          regionCode: market.code,
-          countryName: market.name,
-          currency: market.currency,
-          price: parseFloat(basePrice.toFixed(2)),
-          originalPrice: parseFloat(originalPrice.toFixed(2)),
-          discount: parseFloat(discountPercent.toFixed(1)),
-          priceUSD: convertToUSD(basePrice, market.currency),
-          isFree: Math.random() > 0.95, // 5% chance de ser gratis
-          isOnSale: discountPercent > 0,
-          dealUntil: discountPercent > 0 ? new Date(Date.now() + Math.random() * 30 * 24 * 60 * 60 * 1000).toISOString() : undefined,
-          lastUpdated: new Date().toISOString()
-        };
+      if (mockEnabled && typeof window !== 'undefined' && !window.electronAPI) {
+        return generateMockRegionalPrice(market, convertToUSD);
       }
 
       // En Electron, hacer la llamada real a la API

--- a/XboxNow Professional Scraper Web Application/mocks/demoUtils.ts
+++ b/XboxNow Professional Scraper Web Application/mocks/demoUtils.ts
@@ -1,0 +1,15 @@
+import { randomFloat, randomBool, randomInt, mockEnabled } from './random';
+
+export async function simulateNetworkDelay() {
+  if (!mockEnabled) return;
+  const delay = 1000 + randomFloat(0, 2000);
+  return new Promise(resolve => setTimeout(resolve, delay));
+}
+
+export function mockUploadSuccess() {
+  return mockEnabled ? randomBool(0.1) : true;
+}
+
+export function randomSidebarWidth() {
+  return mockEnabled ? `${randomInt(50, 90)}%` : '70%';
+}

--- a/XboxNow Professional Scraper Web Application/mocks/pricing.ts
+++ b/XboxNow Professional Scraper Web Application/mocks/pricing.ts
@@ -1,0 +1,27 @@
+import { randomFloat, randomBool } from './random';
+import type { XboxMarket, RegionalPrice } from '../types/scraper';
+
+export function generateMockRegionalPrice(
+  market: XboxMarket,
+  convertToUSD: (price: number, currency: string) => number
+): RegionalPrice {
+  const basePrice = randomFloat(10, 70);
+  const discountPercent = randomBool(0.7) ? randomFloat(0, 80) : 0;
+  const originalPrice = basePrice / (1 - discountPercent / 100);
+  return {
+    region: market.region,
+    regionCode: market.code,
+    countryName: market.name,
+    currency: market.currency,
+    price: parseFloat(basePrice.toFixed(2)),
+    originalPrice: parseFloat(originalPrice.toFixed(2)),
+    discount: parseFloat(discountPercent.toFixed(1)),
+    priceUSD: convertToUSD(basePrice, market.currency),
+    isFree: randomBool(0.95),
+    isOnSale: discountPercent > 0,
+    dealUntil: discountPercent > 0
+      ? new Date(Date.now() + randomFloat(0, 30 * 24 * 60 * 60 * 1000)).toISOString()
+      : undefined,
+    lastUpdated: new Date().toISOString()
+  };
+}

--- a/XboxNow Professional Scraper Web Application/mocks/random.ts
+++ b/XboxNow Professional Scraper Web Application/mocks/random.ts
@@ -1,0 +1,25 @@
+const mockEnabled = import.meta.env.VITE_USE_MOCKS === 'true';
+
+let seed = 42;
+function pseudoRandom(): number {
+  const x = Math.sin(seed++) * 10000;
+  return x - Math.floor(x);
+}
+
+export function random(): number {
+  return mockEnabled ? pseudoRandom() : Math.random();
+}
+
+export function randomInt(min: number, max: number): number {
+  return Math.floor(random() * (max - min + 1)) + min;
+}
+
+export function randomFloat(min: number, max: number): number {
+  return random() * (max - min) + min;
+}
+
+export function randomBool(threshold = 0.5): boolean {
+  return random() > threshold;
+}
+
+export { mockEnabled };

--- a/XboxNow Professional Scraper Web Application/mocks/scraper.ts
+++ b/XboxNow Professional Scraper Web Application/mocks/scraper.ts
@@ -1,0 +1,110 @@
+import { randomFloat, randomBool, randomInt } from './random';
+import type { Game, RegionStats, PriceHistory } from '../types/scraper';
+
+export const mockGames: Game[] = [
+  {
+    id: '1',
+    title: 'Halo Infinite',
+    productId: '9PP5G1F0C2B6',
+    region: 'US',
+    imageUrl: 'https://store-images.s-microsoft.com/image/apps.1692.13727851868390641.c9cc5f66-aff8-406c-8c45-8cd48d31bb8d.57f1c8c9-b2c7-416b-b2bb-e89551bb24c7',
+    lowestPriceUsd: 0,
+    originalPriceUsd: 59.99,
+    discount: 100,
+    currency: 'USD',
+    dealUntil: '2024-12-31',
+    releaseDate: '2021-12-08',
+    developer: '343 Industries',
+    publisher: 'Microsoft Studios',
+    categories: ['Action', 'Shooter'],
+    platforms: ['Xbox', 'PC'],
+    description: 'Master Chief returns in Halo Infinite – the next chapter of the legendary franchise.',
+    rating: 'T',
+    url: 'https://www.xbox.com/games/halo-infinite',
+    lastUpdated: new Date().toISOString()
+  },
+  {
+    id: '2',
+    title: 'Forza Horizon 5',
+    productId: '9NKX70BBXVGZ',
+    region: 'US',
+    imageUrl: 'https://store-images.s-microsoft.com/image/apps.12467.13727851868390641.c9cc5f66-aff8-406c-8c45-8cd48d31bb8d.57f1c8c9-b2c7-416b-b2bb-e89551bb24c7',
+    lowestPriceUsd: 29.99,
+    originalPriceUsd: 59.99,
+    discount: 50,
+    currency: 'USD',
+    dealUntil: '2024-01-15',
+    releaseDate: '2021-11-09',
+    developer: 'Playground Games',
+    publisher: 'Microsoft Studios',
+    categories: ['Racing', 'Sports'],
+    platforms: ['Xbox', 'PC'],
+    description: 'Your Ultimate Horizon Adventure awaits! Explore the vibrant and ever-evolving open world landscapes of Mexico.',
+    rating: 'T',
+    url: 'https://www.xbox.com/games/forza-horizon-5',
+    lastUpdated: new Date().toISOString()
+  }
+];
+
+export const mockRegionStats: RegionStats[] = [
+  {
+    region: 'US',
+    totalGames: 2456,
+    averageDiscount: 35,
+    totalValue: 125000,
+    currency: 'USD',
+    lastUpdated: new Date().toISOString()
+  },
+  {
+    region: 'AR',
+    totalGames: 1890,
+    averageDiscount: 42,
+    totalValue: 85000,
+    currency: 'ARS',
+    lastUpdated: new Date().toISOString()
+  }
+];
+
+export const mockPriceHistory: PriceHistory[] = [
+  {
+    productId: '9PP5G1F0C2B6',
+    region: 'US',
+    date: '2024-01-01',
+    price: 59.99,
+    discount: 0,
+    currency: 'USD'
+  },
+  {
+    productId: '9PP5G1F0C2B6',
+    region: 'US',
+    date: '2024-01-15',
+    price: 29.99,
+    discount: 50,
+    currency: 'USD'
+  }
+];
+
+export function generateMockGame(region: string, index: number): Game {
+  const id = `game-${Date.now()}-${randomInt(0, 100000)}`;
+  return {
+    id,
+    title: `Sample Game ${index}`,
+    productId: `9N${randomInt(0, 1e6).toString(36).toUpperCase()}`,
+    region,
+    imageUrl: 'https://via.placeholder.com/300x400',
+    lowestPriceUsd: randomFloat(0, 60),
+    originalPriceUsd: randomFloat(20, 100),
+    discount: randomInt(0, 90),
+    currency: region === 'US' ? 'USD' : 'EUR',
+    dealUntil: randomBool(0.5) ? '2024-12-31' : '',
+    releaseDate: new Date(Date.now() - randomFloat(0, 365 * 24 * 60 * 60 * 1000)).toISOString().split('T')[0],
+    developer: 'Sample Developer',
+    publisher: 'Sample Publisher',
+    categories: ['Action', 'Adventure'],
+    platforms: ['Xbox', 'PC'],
+    description: 'A sample game description',
+    rating: 'T',
+    url: 'https://www.xbox.com/games/sample',
+    lastUpdated: new Date().toISOString()
+  };
+}


### PR DESCRIPTION
## Summary
- separa datos simulados y utilidades en `mocks/`
- inyecta datos de ejemplo mediante `VITE_USE_MOCKS`
- documenta cómo habilitar o desactivar el modo mock

## Testing
- `npm run lint` *(falla: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_6892f59c6548833191fd01a35a04c226